### PR TITLE
Fixed support for nested types

### DIFF
--- a/DocsByReflection/DocsService.cs
+++ b/DocsByReflection/DocsService.cs
@@ -257,7 +257,11 @@ namespace DocsByReflection
 					type.Namespace, 
 					type.Name.Replace("`1", ""),
 					GetTypeFullNameForXmlDoc(type.GetGenericArguments().FirstOrDefault()));
-			}
+            }
+            else if (type.IsNested)
+            {
+                return String.Format(CultureInfo.InvariantCulture, "{0}.{1}.{2}", type.Namespace, type.DeclaringType.Name, type.Name);
+            }
 			else
 			{
 				return String.Format(CultureInfo.InvariantCulture, "{0}.{1}", type.Namespace, type.Name);


### PR DESCRIPTION
Nested types were not working. This is now fixed. E.g.

class foo
{
        enum bar { ... };
}
