### PR TITLE
Fix  GetTypeFullNameForXmlDoc to support multiple generic arguments

### DIFF
--- a/DocsByReflection.UnitTests.Stubs/Stub.cs
+++ b/DocsByReflection.UnitTests.Stubs/Stub.cs
@@ -28,6 +28,15 @@ namespace DocsByReflection.UnitTests.Stubs
 		public void MethodWithoutDoc(string value)
 		{
 		}
+        /// <summary>
+        /// MethodWithComplexGenericParameter method.
+        /// </summary>
+        /// <param name="p">Generic dictionary parameter.</param>
+        public void MethodWithComplexGenericParameter(Dictionary<string, string> p)
+        {
+
+        }
+
 		#endregion
 	}
 }

--- a/DocsByReflection.UnitTests/DocsServiceTest.cs
+++ b/DocsByReflection.UnitTests/DocsServiceTest.cs
@@ -58,6 +58,14 @@ namespace DocsByReflection.UnitTests
             Assert.AreEqual("MethodWithGenericParameter method.", actual.SelectSingleNode("summary").InnerText.Trim());
             Assert.AreEqual("Generic parameter.", actual.SelectSingleNode("param").InnerText.Trim());
         }
+        [Test]
+        public void GetXmlFromMember_MethodWithComplexGenericParameter_XmlElement()
+        {
+            var method = typeof(Stub).GetMethod("MethodWithComplexGenericParameter");
+            var actual = DocsService.GetXmlFromMember(method);
+            Assert.AreEqual("MethodWithComplexGenericParameter method.", actual.SelectSingleNode("summary").InnerText.Trim());
+            Assert.AreEqual("Generic dictionary parameter.", actual.SelectSingleNode("param").InnerText.Trim());
+        }
 
         [Test]
         public void GetXmlFromMember_MethodWithGenericArgumentOnBaseClass_XmlElement()

--- a/DocsByReflection/DocsTypeService.cs
+++ b/DocsByReflection/DocsTypeService.cs
@@ -21,11 +21,16 @@ namespace DocsByReflection
         {
             if (type.MemberType == MemberTypes.TypeInfo && type.IsGenericType && (!type.IsClass || isMethodParameter))
             {
+                //2016-10-06 by Jeffrey, support multiple generic arguments
                 return String.Format(CultureInfo.InvariantCulture,
-                    "{0}.{1}{{{2}}}",
-                    type.Namespace,
-                    type.Name.Replace("`1", ""),
-                    GetTypeFullNameForXmlDoc(type.GetGenericArguments().FirstOrDefault()));
+                     "{0}.{1}{{{2}}}",
+                     type.Namespace,
+                     //type.Name.Replace("`1", ""),
+                     System.Text.RegularExpressions.Regex.Replace(type.Name, "`[0-9]+", ""),
+                     string.Join(",",
+                         type.GetGenericArguments()
+                         .Select(o => GetTypeFullNameForXmlDoc(o)).ToArray()));
+                    //GetTypeFullNameForXmlDoc(type.GetGenericArguments().FirstOrDefault()));
             }
             else if (type.IsNested)
             {


### PR DESCRIPTION
Modify GetTypeFullNameForXmlDoc to support multiple generic arguments ( #5 )
````c#
        public static string GetTypeFullNameForXmlDoc(Type type, bool isMethodParameter = false)
        {
            if (type.MemberType == MemberTypes.TypeInfo && type.IsGenericType && (!type.IsClass || isMethodParameter))
            {
                //2016-10-06 by Jeffrey, support multiple generic arguments
                return String.Format(CultureInfo.InvariantCulture,
                     "{0}.{1}{{{2}}}",
                     type.Namespace,
                     //type.Name.Replace("`1", ""),
                     System.Text.RegularExpressions.Regex.Replace(type.Name, "`[0-9]+", ""),
                     string.Join(",",
                         type.GetGenericArguments()
                         .Select(o => GetTypeFullNameForXmlDoc(o)).ToArray()));
                    //GetTypeFullNameForXmlDoc(type.GetGenericArguments().FirstOrDefault()));
            }
````