### PR TITLE
use location instead of codebase

### DIFF
--- a/DocsByReflection.UnitTests/PathHelperTest.cs
+++ b/DocsByReflection.UnitTests/PathHelperTest.cs
@@ -11,37 +11,24 @@ namespace DocsByReflection.UnitTests
         {
             Assert.Throws<ArgumentNullException>(() =>
             {
-                PathHelper.GetAssemblyDocFileNameFromCodeBase(null);
+                PathHelper.GetAssemblyDocFileNameFromLocation(null);
             });
 
             Assert.Throws<ArgumentNullException>(() =>
             {
-                PathHelper.GetAssemblyDocFileNameFromCodeBase("");
+                PathHelper.GetAssemblyDocFileNameFromLocation("");
             });
-        }
-
-        [Test()]
-        public void GetAssemblyDocFileNameFromCodeBase_DoesNotStartWithPrefix_Exception()
-        {
-            Assert.Throws<DocsByReflectionException>(() =>
-            {
-                PathHelper.GetAssemblyDocFileNameFromCodeBase("file://notExists");
-            }, "Could not ascertain assembly filename from assembly code base 'file://notExists'.");
         }
 
         [Test()]
         public void GetAssemblyDocFileNameFromCodeBase_RightCodeBase_DocFileName()
         {
-            var actual = PathHelper.GetAssemblyDocFileNameFromCodeBase("file:///Users/giacomelli/Dropbox/jogosdaqui/Plataforma/src/jogosdaqui.WebApi/Bin/jogosdaqui.WebApi.dll");
+            var actual = PathHelper.GetAssemblyDocFileNameFromLocation("c:/Users/giacomelli/Dropbox/jogosdaqui/Plataforma/src/jogosdaqui.WebApi/Bin/jogosdaqui.WebApi.dll");
 
-            if (Environment.OSVersion.Platform == PlatformID.MacOSX || Environment.OSVersion.Platform == PlatformID.Unix)
-            {
-                Assert.AreEqual("/Users/giacomelli/Dropbox/jogosdaqui/Plataforma/src/jogosdaqui.WebApi/Bin/jogosdaqui.WebApi.xml", actual);
-            }
-            else
-            {
-                Assert.AreEqual("Users/giacomelli/Dropbox/jogosdaqui/Plataforma/src/jogosdaqui.WebApi/Bin/jogosdaqui.WebApi.xml", actual);
-            }
+            Assert.AreEqual(
+                "c:/Users/giacomelli/Dropbox/jogosdaqui/Plataforma/src/jogosdaqui.WebApi/Bin/jogosdaqui.WebApi.xml",
+                actual
+            );
         }
     }
 }

--- a/DocsByReflection/DocsAssemblyService.cs
+++ b/DocsByReflection/DocsAssemblyService.cs
@@ -77,7 +77,7 @@ namespace DocsByReflection
         /// <returns>The XML document</returns>
         private static XmlDocument GetXmlFromAssemblyNonCached(Assembly assembly)
         {
-            string filePath = PathHelper.GetAssemblyDocFileNameFromCodeBase(assembly.CodeBase);
+            string filePath = PathHelper.GetAssemblyDocFileNameFromLocation(assembly.Location);
 
             try
             {

--- a/DocsByReflection/PathHelper.cs
+++ b/DocsByReflection/PathHelper.cs
@@ -8,33 +8,19 @@ namespace DocsByReflection
 	/// </summary>
 	public static class PathHelper
 	{
-		#region Methods
-		/// <summary>
-		/// Gets the assembly document file name from code base.
-		/// </summary>
-		/// <returns>The assembly document file name from code base.</returns>
-		/// <param name="assemblyCodeBase">Assemby code base.</param>
-		public static string GetAssemblyDocFileNameFromCodeBase(string assemblyCodeBase)
+        #region Methods
+        /// <summary>
+        /// Gets the assembly document file name from location.
+        /// </summary>
+        /// <returns>The assembly document file name from location.</returns>
+        /// <param name="assemblyLocation">Assemby location.</param>
+        public static string GetAssemblyDocFileNameFromLocation(string assemblyLocation)
 		{
-			if (string.IsNullOrWhiteSpace (assemblyCodeBase)) {
-				throw new ArgumentNullException ("assemblyCodeBase");
+			if (string.IsNullOrWhiteSpace (assemblyLocation)) {
+				throw new ArgumentNullException (nameof(assemblyLocation));
 			}
 
-			var prefix = "file:///";
-
-			if (assemblyCodeBase.StartsWith (prefix, StringComparison.OrdinalIgnoreCase)) {
-				var filePath = assemblyCodeBase.Substring (prefix.Length);
-
-				if (Environment.OSVersion.Platform == PlatformID.MacOSX || Environment.OSVersion.Platform == PlatformID.Unix) {
-					filePath = "/" + filePath;
-				}
-
-				return Path.ChangeExtension (filePath, ".xml");
-			}
-			else
-			{
-				throw new DocsByReflectionException(string.Format("Could not ascertain assembly filename from assembly code base '{0}'.", assemblyCodeBase));
-			}
+			return Path.ChangeExtension (assemblyLocation, ".xml");
 		}
 		#endregion
 	}


### PR DESCRIPTION
- assembly.codebase is deprecated
- assembly.location contains a normal file path without file:// prefix
- supports UNC shares (see issue #18), which previous code did not
- removes need for mac/linux special handling